### PR TITLE
security: use shared input sanitizer for issue processing

### DIFF
--- a/.github/workflows/process-created-issue.yml
+++ b/.github/workflows/process-created-issue.yml
@@ -79,7 +79,7 @@ jobs:
             );
             core.setOutput('product_compatibility', JSON.stringify(productCompatibility));
 
-      - name: Sanitize and validate inputs
+      - name: Sanitize inputs
         id: sanitize
         uses: PortSwigger/shared-workflows/sanitize-inputs@ff879d3c7b4476af5ed83d7d81438c7258217644 # v1.0.0
         with:
@@ -94,7 +94,8 @@ jobs:
     needs: extract-issue-details
     if: |
       !cancelled() &&
-      contains(github.event.issue.body, 'template:01-submit-extension')
+      contains(github.event.issue.body, 'template:01-submit-extension') &&
+      needs.extract-issue-details.outputs.error_message == ''
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -117,7 +118,6 @@ jobs:
 
       - name: Verify repository exists and is not a fork
         id: validate_repo
-        if: needs.extract-issue-details.outputs.error_message == ''
         run: |
           python3 .github/scripts/validate_repo.py
         env:
@@ -126,7 +126,7 @@ jobs:
 
       - name: Identify extension language
         id: extension_language
-        if: needs.extract-issue-details.outputs.error_message == '' && steps.validate_repo.outcome == 'success'
+        if: steps.validate_repo.outcome == 'success'
         run: |
           python3 .github/scripts/detect_language.py
         env:


### PR DESCRIPTION
## Summary
- Split the `extract-issue-details` job into two steps: raw extraction and sanitization
- Extraction step now only parses the issue template body — no validation or `throw` calls
- Sanitization delegated to `PortSwigger/shared-workflows/sanitize-inputs` composite action
- Removes inline `sanitizeText()`, `validateVersion()`, and `validateUrl()` functions
- Job outputs now wire through the sanitize step; downstream jobs are unaffected
- `validate_repo.py` remains as domain-specific logic in this repo

This shares the sanitization logic across extension-portal, bambdas, and BChecks.

## Test plan
- [ ] Create a test extension submission issue and verify it processes correctly
- [ ] Create a test update submission issue and verify it processes correctly
- [ ] Verify validation errors (bad URL, missing fields) still produce correct error comments
- [ ] Verify downstream jobs (Jira ticket, Zoom notification) receive sanitized values

🤖 Generated with [Claude Code](https://claude.com/claude-code)